### PR TITLE
Fix remote commands in execSync and spawnSync

### DIFF
--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -341,15 +341,12 @@ async function runBenchmark(task) {
     if ('upload' in util.args) {
       // Ensure server has the device folder
       let serverFolder = `/workspace/project/work/ort/perf/${util.platform}/${util['gpuDeviceId']}`;
-      let result = spawnSync(util.ssh, ['wp@wp-27.sh.intel.com', `ls ${serverFolder}`]);
+      let result = spawnSync(util.ssh(`ls ${serverFolder}`), { shell: true });
       if (result.status != 0) {
-        spawnSync(util.ssh, ['wp@wp-27.sh.intel.com', `mkdir -p ${serverFolder}`]);
+        spawnSync(util.ssh(`mkdir -p ${serverFolder}`), { shell: true });
       }
 
-      result = spawnSync(util.scp, [
-        file,
-        `wp@wp-27.sh.intel.com:${serverFolder}`
-      ]);
+      result = spawnSync(util.scp(file, `${util.server}:${serverFolder}`), { shell: true });
       if (result.status !== 0) {
         util.log('[ERROR] Failed to upload report');
       } else {

--- a/src/report.js
+++ b/src/report.js
@@ -219,7 +219,7 @@ async function report(results) {
   let configTable = '<table><tr><th>Category</th><th>Info</th></tr>';
   if ('upload' in util.args || 'server-info' in util.args) {
     util['serverRepoCommit'] =
-      execSync(util.ssh, ['wp@wp-27.sh.intel.com', '"cd /workspace/project/onnxruntime && git rev-parse HEAD"'])
+      execSync(util.ssh('"cd /workspace/project/onnxruntime && git rev-parse HEAD"'))
         .toString();
   }
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -43,7 +43,7 @@ async function upload() {
     // check if file exists in remote
     let serverFolder = `/workspace/project/work/ort/perf/${util.platform}/${util['gpuDeviceId']}`;
     result = spawnSync(
-      util.ssh, ['wp@wp-27.sh.intel.com', `ls ${serverFolder}/${fileName}`]);
+      util.ssh(`ls ${serverFolder}/${fileName}`), { shell: true });
     if (result.status == 0) {
       util.log(`[INFO] ${fullPath} already exists in server`);
       continue;
@@ -51,7 +51,7 @@ async function upload() {
 
     // upload the file
     result =
-      spawnSync(util.scp, [fullPath, `wp@wp-27.sh.intel.com:${serverFolder}`]);
+      spawnSync(util.scp(fullPath, `${util.server}:${serverFolder}`), { shell: true });
     if (result.status !== 0) {
       util.log(`[ERROR] ${fullPath} Failed to upload`);
     } else {

--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,8 @@ let taskMetrics = {
 const outDir = path.join(path.resolve(__dirname), '../out');
 ensureDir(outDir);
 
+const server = 'wp@wp-27.sh.intel.com';
+
 const sshKey = path.join(os.homedir(), '.ssh/id_rsa_common');
 const remoteCmdArgs = fs.existsSync(sshKey) ? `-i ${sshKey}` : '';
 
@@ -68,6 +70,14 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function scp(src, dest) {
+  return `scp ${remoteCmdArgs} ${src} ${dest}`;
+}
+
+function ssh(cmd) {
+  return `ssh ${remoteCmdArgs} ${server} ${cmd}`
+}
+
 module.exports = {
   allEps: allEps,
   conformanceEps: [],
@@ -75,6 +85,7 @@ module.exports = {
   browserArgs:
     '--enable-features=WebAssemblyThreads,SharedArrayBuffer,WebAssemblySimd,MediaFoundationD3D11VideoCapture --start-maximized --enable-dawn-features=allow_unsafe_apis,use_dxc --enable-webgpu-developer-features --enable-features=MachineLearningNeuralNetworkService --enable-experimental-web-platform-features',
   hostname: os.hostname(),
+  server: server,
   outDir: outDir,
   parameters: parameters,
   performanceEps: [],
@@ -85,8 +96,6 @@ module.exports = {
   toolkitUrlArgs: '',
   unitEps: [],
   updateModelNames: [],
-  scp: `scp ${remoteCmdArgs}`,
-  ssh: `ssh ${remoteCmdArgs}`,
 
   capitalize: capitalize,
   ensureDir: ensureDir,
@@ -96,4 +105,6 @@ module.exports = {
   log: log,
   sleep: sleep,
   uncapitalize: uncapitalize,
+  scp: scp,
+  ssh: ssh,
 };


### PR DESCRIPTION
- execSync does not support passing args, only supports one command string.
- spawnSync supports passing args, but the first arg must be a callable program, set shell to true to run commands inside of a shell, so we can pass command string.